### PR TITLE
FISH-6556 Concurrency Fix Web Profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.glassfish</groupId>
     <artifactId>jakarta.enterprise.concurrent</artifactId>
-    <version>3.0.0.payara-p1</version>
+    <version>3.0.0.payara-p2</version>
     <packaging>jar</packaging>
 
     <name>org.glassfish.jakarta.enterprise.concurrent</name>

--- a/src/main/java/org/glassfish/enterprise/concurrent/ManagedExecutorServiceImpl.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/ManagedExecutorServiceImpl.java
@@ -59,10 +59,11 @@ public class ManagedExecutorServiceImpl extends AbstractManagedExecutorService {
         if (useForkJoinPool) {
             executor = new ManagedForkJoinPool();
         } else {
-            executor = new ManagedThreadPoolExecutor(corePoolSize, maxPoolSize,
+            ManagedThreadPoolExecutor mtpExecutor = new ManagedThreadPoolExecutor(corePoolSize, maxPoolSize,
                     keepAliveTime, keepAliveTimeUnit, queue,
                     this.managedThreadFactory);
-            ((ManagedThreadPoolExecutor) executor).setThreadLifeTime(threadLifeTime);
+            mtpExecutor.setThreadLifeTime(threadLifeTime);
+            executor = mtpExecutor;
         }
         adapter = new ManagedExecutorServiceAdapter(this);
     }
@@ -117,7 +118,7 @@ public class ManagedExecutorServiceImpl extends AbstractManagedExecutorService {
     public void execute(Runnable command) {
         ManagedFutureTask<Void> task = getNewTaskFor(command, null);
         task.submitted();
-        ((ExecutorService) executor).execute(task);
+        executor.execute(task);
     }
 
     /**
@@ -133,7 +134,7 @@ public class ManagedExecutorServiceImpl extends AbstractManagedExecutorService {
 
     @Override
     protected ExecutorService getExecutor() {
-        return (ExecutorService) executor;
+        return executor;
     }
 
     @Override

--- a/src/main/java/org/glassfish/enterprise/concurrent/internal/ManagedExecutor.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/internal/ManagedExecutor.java
@@ -41,30 +41,32 @@
 package org.glassfish.enterprise.concurrent.internal;
 
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
-public interface ManagedExecutor {
-    public long getTaskCount();
+public interface ManagedExecutor extends ExecutorService {
 
-    public long getCompletedTaskCount();
+    long getTaskCount();
 
-    public int getCorePoolSize();
+    long getCompletedTaskCount();
 
-    public int getActiveCount();
+    int getCorePoolSize();
 
-    public long getKeepAliveTime(TimeUnit timeUnit);
+    int getActiveCount();
 
-    public int getLargestPoolSize();
+    long getKeepAliveTime(TimeUnit timeUnit);
 
-    public int getMaximumPoolSize();
+    int getLargestPoolSize();
 
-    public int getPoolSize();
+    int getMaximumPoolSize();
 
-    public BlockingQueue getQueue();
+    int getPoolSize();
 
-    public RejectedExecutionHandler getRejectedExecutionHandler();
+    BlockingQueue getQueue();
 
-    public ThreadFactory getThreadFactory();
+    RejectedExecutionHandler getRejectedExecutionHandler();
+
+    ThreadFactory getThreadFactory();
 }

--- a/src/main/java/org/glassfish/enterprise/concurrent/internal/ManagedScheduledThreadPoolExecutor.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/internal/ManagedScheduledThreadPoolExecutor.java
@@ -645,7 +645,9 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
             // cancel the next scheduled task if there is one
             ManagedTriggerSingleFutureTask<V> future = getCurrentFuture();
             if (future != null) {
-                return future.cancel(mayInterruptIfRunning);
+                boolean alreadyDone = future.isDone();
+                //  return true if the currentFuture is "Completed normally"
+                return future.cancel(mayInterruptIfRunning) || alreadyDone;
             }
             return true;
         }

--- a/src/main/java/org/glassfish/enterprise/concurrent/internal/ManagedScheduledThreadPoolExecutor.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/internal/ManagedScheduledThreadPoolExecutor.java
@@ -538,20 +538,6 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
             this.scheduledRunTime = scheduledRunTime;
         }
 
-        ManagedTriggerSingleFutureTask(AbstractManagedExecutorService executor, 
-                                 Runnable r,
-                                 long ns,
-                                 long scheduledRunTime,
-                                 TriggerControllerFuture controller) {
-            super(executor, r, null, ns);
-            this.controller = controller;
-            this.scheduledRunTime = scheduledRunTime;
-        }
-        
-        private long getDelayFromDate(Date nextRunTime) {
-            return triggerTime(nextRunTime.getTime() - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
-        }
-        
         @Override
         public boolean isPeriodic() {
             return false;


### PR DESCRIPTION
This commit is fixing failing testScheduleWithCronTrigger test, when ScheduledFuture.cancel was expecting true, but getting false. The issue was, that internal Future returned true as one run of the schedule succeeding. This isn't related to the cancelled schedule. I changed the behaviour to succeded, even if the internal Future is done (which follows the contract of the cancel method).